### PR TITLE
add --cover-package options to nosetests call when running run_tests with -c option

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ aliases:
   - &conda_upload
     name: conda_upload
     command: |
-       if [[ $CIRCLE_BRANCH != 'master' ]]; then
+       if [[ $CIRCLE_BRANCH != 'add_coverage' ]]; then
           exit 0
        fi
        export PATH=${HOME}/project/$WORKDIR/miniconda/bin:$PATH
@@ -65,8 +65,8 @@ aliases:
        export PKG_NAME=testsrunner
        export USER=cdat
        export VERSION=8.0
-       export LABEL=nightly
-       python ./prep_for_build.py -l $VERSION 
+       export LABEL=linatest
+       python ./prep_for_build.py -l $VERSION -b 'add_coverage' 
        conda build $PKG_NAME -c cdat/label/nightly -c conda-forge -c cdat --python=2.7
        conda build $PKG_NAME -c cdat/label/nightly -c conda-forge -c cdat --python=3.6
        anaconda -t $CONDA_UPLOAD_TOKEN upload -u $USER -l $LABEL $CONDA_BLD_PATH/$OS/$PKG_NAME-$VERSION.`date +%Y*`0.tar.bz2 --force

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ aliases:
   - &conda_upload
     name: conda_upload
     command: |
-       if [[ $CIRCLE_BRANCH != 'add_coverage' ]]; then
+       if [[ $CIRCLE_BRANCH != 'master' ]]; then
           exit 0
        fi
        export PATH=${HOME}/project/$WORKDIR/miniconda/bin:$PATH
@@ -65,8 +65,8 @@ aliases:
        export PKG_NAME=testsrunner
        export USER=cdat
        export VERSION=8.0
-       export LABEL=linatest
-       python ./prep_for_build.py -l $VERSION -b 'add_coverage' 
+       export LABEL=nightly
+       python ./prep_for_build.py -l $VERSION 
        conda build $PKG_NAME -c cdat/label/nightly -c conda-forge -c cdat --python=2.7
        conda build $PKG_NAME -c cdat/label/nightly -c conda-forge -c cdat --python=3.6
        anaconda -t $CONDA_UPLOAD_TOKEN upload -u $USER -l $LABEL $CONDA_BLD_PATH/$OS/$PKG_NAME-$VERSION.`date +%Y*`0.tar.bz2 --force

--- a/lib/TestRunnerBase.py
+++ b/lib/TestRunnerBase.py
@@ -136,13 +136,31 @@ class TestRunnerBase(object):
         """Place holder extend this if you want more options"""
         return []
 
+    def __get_coverage_packages(self):
+        pkgs = ["cdms2", "cdutil", "genutil", "wk", "pcmdi_metrics",
+                "vcs", "vcsaddons", "thermo", "dv3d"]
+        python_ver = "python{a}.{i}".format(a=sys.version_info.major,
+                                            i=sys.version_info.minor)
+        coverage_opts = ""
+        path = os.path.join(sys.prefix, 'lib', python_ver, 'site-packages')
+        for pkg in pkgs:
+            opt = "--cover-package {p}".format(p=os.path.join(path, pkg))
+            coverage_opts = "{curr} {new}".format(curr=coverage_opts,
+                                                  new=opt)
+        return coverage_opts.split()
+
     def __do_run_tests(self, test_names):
         ret_code = SUCCESS
-        p = multiprocessing.Pool(self.ncpus)
+        if self.args.coverage:
+            p = multiprocessing.Pool(1)
+        else:
+            p = multiprocessing.Pool(self.ncpus)
         # Let's prep the options once and for all
         opts = self._prep_nose_options()
         if self.args.coverage:
-            opts += ["--with-coverage", "--cover-html", "--cover-xml"]
+            coverage_opts = self.__get_coverage_packages()
+            opts += ["--with-coverage", "--cover-html"]
+            opts += coverage_opts
         for att in self.args.attributes:
             opts += ["-A", att]
         func = partial(run_nose, opts, self.verbosity)


### PR DESCRIPTION
I have tested this out by running one of cdat nightly and turn on coverage.
Once testsrunner changes is in nightly, I will update our cdat to run a job with coverage.
