### PR TITLE
Add coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ aliases:
        source activate py3
        python run_tests.py -H -v2 -n 2
        PY3_RESULT=$?
-       echo "*** py3 test result: "${PY3_RESULT}
+       echo "**** py3 test result: "${PY3_RESULT}
        RESULT=$(( $RESULT + $PY3_RESULT))
        exit $RESULT
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,6 @@ aliases:
        RESULT=$(( $RESULT + $PY3_RESULT))
        exit $RESULT
 
-
   - &conda_upload
     name: conda_upload
     command: |
@@ -112,10 +111,9 @@ jobs:
           path: tests_png
           destination: tests_png
 
-
 workflows:
   version: 2
   testsrunner:
     jobs:
       - macos_testsrunner
-      #- linux_testsrunner
+      - linux_testsrunner

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ aliases:
   - &conda_upload
     name: conda_upload
     command: |
-       if [[ $CIRCLE_BRANCH != 'master' ]]; then
+       if [[ $CIRCLE_BRANCH != 'add_coverage' ]]; then
           exit 0
        fi
        export PATH=${HOME}/project/$WORKDIR/miniconda/bin:$PATH
@@ -65,8 +65,8 @@ aliases:
        export PKG_NAME=testsrunner
        export USER=cdat
        export VERSION=8.0
-       export LABEL=nightly
-       python ./prep_for_build.py -l $VERSION 
+       export LABEL=linatest
+       python ./prep_for_build.py -l $VERSION -b 'add_coverage' 
        conda build $PKG_NAME -c cdat/label/nightly -c conda-forge -c cdat --python=2.7
        conda build $PKG_NAME -c cdat/label/nightly -c conda-forge -c cdat --python=3.6
        anaconda -t $CONDA_UPLOAD_TOKEN upload -u $USER -l $LABEL $CONDA_BLD_PATH/$OS/$PKG_NAME-$VERSION.`date +%Y*`0.tar.bz2 --force

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ aliases:
        source activate py3
        python run_tests.py -H -v2 -n 2
        PY3_RESULT=$?
-       echo "**** py3 test result: "${PY3_RESULT}
+       echo "*** py3 test result: "${PY3_RESULT}
        RESULT=$(( $RESULT + $PY3_RESULT))
        exit $RESULT
 
@@ -118,4 +118,4 @@ workflows:
   testsrunner:
     jobs:
       - macos_testsrunner
-      - linux_testsrunner
+      #- linux_testsrunner

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ aliases:
   - &conda_upload
     name: conda_upload
     command: |
-       if [[ $CIRCLE_BRANCH != 'master' ]]; then
+       if [[ $CIRCLE_BRANCH != 'add_coverage' ]]; then
           exit 0
        fi
        export PATH=${HOME}/project/$WORKDIR/miniconda/bin:$PATH
@@ -64,8 +64,8 @@ aliases:
        export PKG_NAME=testsrunner
        export USER=cdat
        export VERSION=8.0
-       export LABEL=nightly
-       python ./prep_for_build.py -l $VERSION
+       export LABEL=linatest
+       python ./prep_for_build.py -l $VERSION -b 'add_coverage'
        conda build $PKG_NAME -c cdat/label/nightly -c conda-forge -c cdat --python=2.7
        conda build $PKG_NAME -c cdat/label/nightly -c conda-forge -c cdat --python=3.6
        anaconda -t $CONDA_UPLOAD_TOKEN upload -u $USER -l $LABEL $CONDA_BLD_PATH/$OS/$PKG_NAME-$VERSION.`date +%Y*`0.tar.bz2 --force

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ aliases:
   - &conda_upload
     name: conda_upload
     command: |
-       if [[ $CIRCLE_BRANCH != 'add_coverage' ]]; then
+       if [[ $CIRCLE_BRANCH != 'master' ]]; then
           exit 0
        fi
        export PATH=${HOME}/project/$WORKDIR/miniconda/bin:$PATH
@@ -65,8 +65,8 @@ aliases:
        export PKG_NAME=testsrunner
        export USER=cdat
        export VERSION=8.0
-       export LABEL=linatest
-       python ./prep_for_build.py -l $VERSION -b 'add_coverage' 
+       export LABEL=nightly
+       python ./prep_for_build.py -l $VERSION
        conda build $PKG_NAME -c cdat/label/nightly -c conda-forge -c cdat --python=2.7
        conda build $PKG_NAME -c cdat/label/nightly -c conda-forge -c cdat --python=3.6
        anaconda -t $CONDA_UPLOAD_TOKEN upload -u $USER -l $LABEL $CONDA_BLD_PATH/$OS/$PKG_NAME-$VERSION.`date +%Y*`0.tar.bz2 --force

--- a/lib/TestRunnerBase.py
+++ b/lib/TestRunnerBase.py
@@ -86,10 +86,7 @@ class TestRunnerBase(object):
         the set of failed test names that is listed in <tests>
         """
         if tests is None or len(tests) == 0:
-            # run all tests
-            # test_names = glob.glob("tests/test_*py")
             test_names = glob.glob("{w}/tests/test_*py".format(w=workdir))
-            print("xxx test_names: ", test_names)
         else:
             test_names = set(tests)
 

--- a/lib/TestRunnerBase.py
+++ b/lib/TestRunnerBase.py
@@ -88,7 +88,7 @@ class TestRunnerBase(object):
         if tests is None or len(tests) == 0:
             # run all tests
             # test_names = glob.glob("tests/test_*py")
-            test_names = glob.glob(os.path.join(workdir, 'tests', '*.py')
+            test_names = glob.glob(os.path.join(workdir, 'tests', '*.py'))
         else:
             test_names = set(tests)
 

--- a/lib/TestRunnerBase.py
+++ b/lib/TestRunnerBase.py
@@ -136,6 +136,19 @@ class TestRunnerBase(object):
         """Place holder extend this if you want more options"""
         return []
 
+    def __get_coverage_packages_opt(self):
+        with open('.coverage.cfg', 'r') as f:
+            coverage_info = json.load(f)
+
+        python_ver = "python{a}.{i}".format(a=sys.version_info.major,
+                                            i=sys.version_info.minor)
+        coverage_opts = []
+        path = os.path.join(sys.prefix, 'lib', python_ver, 'site-packages')
+        for pkg in coverage_info["include"]:
+            opt = "--cover-package {p}".format(p=os.path.join(path, pkg))
+            coverage_opts = coverage_opts.append(opt)
+        return coverage_opts
+
     def __get_coverage_packages_TO_BE_REMOVED(self):
         pkgs = ["cdms2", "cdutil", "genutil", "wk", "pcmdi_metrics",
                 "vcs", "vcsaddons", "thermo", "dv3d"]
@@ -158,10 +171,10 @@ class TestRunnerBase(object):
         # Let's prep the options once and for all
         opts = self._prep_nose_options()
         if self.args.coverage:
-            # coverage_opts = self.__get_coverage_packages()
+            coverage_opts = self.__get_coverage_packages_opt()
             opts += ["--with-coverage", "--cover-html"]
-            # opts += coverage_opts
         for att in self.args.attributes:
+            opts += coverage_opts 
             opts += ["-A", att]
         func = partial(run_nose, opts, self.verbosity)
         try:

--- a/lib/TestRunnerBase.py
+++ b/lib/TestRunnerBase.py
@@ -144,14 +144,13 @@ class TestRunnerBase(object):
 
         python_ver = "python{a}.{i}".format(a=sys.version_info.major,
                                             i=sys.version_info.minor)
-        coverage_opts = []
+        coverage_opts = ""
         path = os.path.join(sys.prefix, 'lib', python_ver, 'site-packages')
         for pkg in coverage_info["include"]:
-            # opt = "--cover-package {p}".format(p=os.path.join(path, pkg))
-            # coverage_opts.append(opt)
-            coverage_opts.append("--cover-package")
-            coverage_opts.append(os.path.join(path, pkg))
-        return coverage_opts
+            opt = "--cover-package {p}".format(p=os.path.join(path, pkg))
+            coverage_opts = "{curr} {new}".format(curr=coverage_opts,
+                                                  new=opt)
+        return coverage_opts.split()
 
     def __do_run_tests(self, test_names):
         ret_code = SUCCESS

--- a/lib/TestRunnerBase.py
+++ b/lib/TestRunnerBase.py
@@ -163,8 +163,8 @@ class TestRunnerBase(object):
         for pkg in coverage_info["include"]:
             pkg_files = glob.glob(os.path.join(path, pkg, "*.py"))
             cmd = "coverage report {path}".format(path=" ".join(pkg_files))
-            self.__run_cmd(cmd)
-            print("----------------------------------------------------------")
+            # set popen_bufsize to 1 because some coverage output is large.
+            run_command(cmd, True, 2, 1)
 
     def __do_run_tests(self, test_names):
         ret_code = SUCCESS

--- a/lib/TestRunnerBase.py
+++ b/lib/TestRunnerBase.py
@@ -161,7 +161,7 @@ class TestRunnerBase(object):
 
         path = os.path.join(sys.prefix, 'lib', python_ver, 'site-packages')
         for pkg in coverage_info["include"]:
-            pkg_files = glob.glob(os.path.join(path, pkg))
+            pkg_files = glob.glob(os.path.join(path, pkg, "*"))
             cmd = "coverage report {path}".format(path=" ".join(pkg_files))
             self.__run_cmd(cmd)
 

--- a/lib/TestRunnerBase.py
+++ b/lib/TestRunnerBase.py
@@ -158,9 +158,9 @@ class TestRunnerBase(object):
         # Let's prep the options once and for all
         opts = self._prep_nose_options()
         if self.args.coverage:
-            #coverage_opts = self.__get_coverage_packages()
+            # coverage_opts = self.__get_coverage_packages()
             opts += ["--with-coverage", "--cover-html"]
-            #opts += coverage_opts
+            # opts += coverage_opts
         for att in self.args.attributes:
             opts += ["-A", att]
         func = partial(run_nose, opts, self.verbosity)

--- a/lib/TestRunnerBase.py
+++ b/lib/TestRunnerBase.py
@@ -74,7 +74,7 @@ class TestRunnerBase(object):
             download_sample_data_files(
                 test_data_files_info, get_sampledata_path())
 
-    def __get_tests(self, tests=None):
+    def _get_tests(self, tests=None):
         """
         get_tests() gets the list of test names to run.
         If <failed_only> is False, returns the set of the specified
@@ -104,9 +104,9 @@ class TestRunnerBase(object):
 
         return test_names
 
-    def __get_baseline(self, workdir):
+    def _get_baseline(self, workdir):
         """
-        __get_baseline(self, workdir):
+        _get_baseline(self, workdir):
         <workdir> : should be repo dir of the test
         """
         os.chdir(workdir)
@@ -166,7 +166,7 @@ class TestRunnerBase(object):
             # set popen_bufsize to 1 because some coverage output is large.
             run_command(cmd, True, 2, 1)
 
-    def __do_run_tests(self, test_names):
+    def _do_run_tests(self, test_names):
         ret_code = SUCCESS
         if self.args.coverage:
             p = multiprocessing.Pool(1)
@@ -294,7 +294,7 @@ class TestRunnerBase(object):
         print("<tfoot><tr><th>Test</th><th>Result</th><th>Start Time</th>"
               "<th>End Time</th><th>Time</th></tr></tfoot>", file=fh)
 
-    def __generate_html(self, workdir, image_difference=True):
+    def _generate_html(self, workdir, image_difference=True):
         os.chdir(workdir)
         if not os.path.exists("tests_html"):
             os.makedirs("tests_html")
@@ -373,7 +373,7 @@ class TestRunnerBase(object):
         os.chdir(workdir)
         webbrowser.open("file://%s/tests_html/index.html" % workdir)
 
-    def __package_results(self, workdir):
+    def _package_results(self, workdir):
         os.chdir(workdir)
         import tarfile
         tnm = "results_%s_%s_%s.tar.bz2" % (
@@ -394,19 +394,19 @@ class TestRunnerBase(object):
         tests  : a space separated list of test cases
         """
         os.chdir(workdir)
-        test_names = self.__get_tests(self.args.tests)
+        test_names = self._get_tests(self.args.tests)
 
         if self.args.checkout_baseline:
-            ret_code = self.__get_baseline(workdir)
+            ret_code = self._get_baseline(workdir)
             if ret_code != SUCCESS:
                 return(ret_code)
 
-        ret_code = self.__do_run_tests(test_names)
+        ret_code = self._do_run_tests(test_names)
 
         if self.args.html or self.args.package:
-            self.__generate_html(workdir)
+            self._generate_html(workdir)
 
         if self.args.package:
-            self.__package_results(workdir)
+            self._package_results(workdir)
 
         return ret_code

--- a/lib/TestRunnerBase.py
+++ b/lib/TestRunnerBase.py
@@ -138,8 +138,8 @@ class TestRunnerBase(object):
         """Place holder extend this if you want more options"""
         return []
 
-    def __get_coverage_packages_opt(self):
-        with open('tests/coverage.json', 'r') as f:
+    def __get_coverage_packages_opt(self, workdir):
+        with open(os.path.join(workdir, 'tests', 'coverage.json'), 'r') as f:
             coverage_info = json.load(f)
 
         python_ver = "python{a}.{i}".format(a=sys.version_info.major,
@@ -152,8 +152,8 @@ class TestRunnerBase(object):
                                                   new=opt)
         return coverage_opts.split()
 
-    def __collect_coverage(self):
-        with open('tests/coverage.json', 'r') as f:
+    def __collect_coverage(self, workdir):
+        with open(os.path.join(workdir, 'tests', 'coverage.json'), 'r') as f:
             coverage_info = json.load(f)
 
         python_ver = "python{a}.{i}".format(a=sys.version_info.major,
@@ -166,7 +166,7 @@ class TestRunnerBase(object):
             # set popen_bufsize to 1 because some coverage output is large.
             run_command(cmd, True, 2, 1)
 
-    def _do_run_tests(self, test_names):
+    def _do_run_tests(self, workdir, test_names):
         ret_code = SUCCESS
         if self.args.coverage:
             p = multiprocessing.Pool(1)
@@ -175,7 +175,7 @@ class TestRunnerBase(object):
         # Let's prep the options once and for all
         opts = self._prep_nose_options()
         if self.args.coverage:
-            coverage_opts = self.__get_coverage_packages_opt()
+            coverage_opts = self.__get_coverage_packages_opt(workdir)
             opts += ["--with-coverage", "--cover-html"]
             opts += coverage_opts
         for att in self.args.attributes:
@@ -217,7 +217,7 @@ class TestRunnerBase(object):
             ret_code = FAILURE
 
         if self.args.coverage:
-            self.__collect_coverage()
+            self.__collect_coverage(workdir)
 
         return ret_code
 
@@ -401,7 +401,7 @@ class TestRunnerBase(object):
             if ret_code != SUCCESS:
                 return(ret_code)
 
-        ret_code = self._do_run_tests(test_names)
+        ret_code = self._do_run_tests(workdir, test_names)
 
         if self.args.html or self.args.package:
             self._generate_html(workdir)

--- a/lib/TestRunnerBase.py
+++ b/lib/TestRunnerBase.py
@@ -136,13 +136,31 @@ class TestRunnerBase(object):
         """Place holder extend this if you want more options"""
         return []
 
+    def __get_coverage_packages_TO_BE_REMOVED(self):
+        pkgs = ["cdms2", "cdutil", "genutil", "wk", "pcmdi_metrics",
+                "vcs", "vcsaddons", "thermo", "dv3d"]
+        python_ver = "python{a}.{i}".format(a=sys.version_info.major,
+                                            i=sys.version_info.minor)
+        coverage_opts = ""
+        path = os.path.join(sys.prefix, 'lib', python_ver, 'site-packages')
+        for pkg in pkgs:
+            opt = "--cover-package {p}".format(p=os.path.join(path, pkg))
+            coverage_opts = "{curr} {new}".format(curr=coverage_opts,
+                                                  new=opt)
+        return coverage_opts.split()
+
     def __do_run_tests(self, test_names):
         ret_code = SUCCESS
-        p = multiprocessing.Pool(self.ncpus)
+        if self.args.coverage:
+            p = multiprocessing.Pool(1)
+        else:
+            p = multiprocessing.Pool(self.ncpus)
         # Let's prep the options once and for all
         opts = self._prep_nose_options()
         if self.args.coverage:
-            opts += ["--with-coverage", "--cover-html", "--cover-xml"]
+            #coverage_opts = self.__get_coverage_packages()
+            opts += ["--with-coverage", "--cover-html"]
+            #opts += coverage_opts
         for att in self.args.attributes:
             opts += ["-A", att]
         func = partial(run_nose, opts, self.verbosity)

--- a/lib/TestRunnerBase.py
+++ b/lib/TestRunnerBase.py
@@ -153,6 +153,7 @@ class TestRunnerBase(object):
         return coverage_opts.split()
 
     def __collect_coverage(self):
+        print("xxx __collect_coverage() xxx")
         with open('tests/coverage.json', 'r') as f:
             coverage_info = json.load(f)
 

--- a/lib/TestRunnerBase.py
+++ b/lib/TestRunnerBase.py
@@ -148,7 +148,7 @@ class TestRunnerBase(object):
         path = os.path.join(sys.prefix, 'lib', python_ver, 'site-packages')
         for pkg in coverage_info["include"]:
             opt = "--cover-package {p}".format(p=os.path.join(path, pkg))
-            coverage_opts += opt
+            coverage_opts.append(opt)
         return coverage_opts
 
     def __do_run_tests(self, test_names):

--- a/lib/TestRunnerBase.py
+++ b/lib/TestRunnerBase.py
@@ -89,6 +89,7 @@ class TestRunnerBase(object):
             # run all tests
             # test_names = glob.glob("tests/test_*py")
             test_names = glob.glob("{w}/tests/test_*py".format(w=workdir))
+            print("xxx test_names: ", test_names)
         else:
             test_names = set(tests)
 

--- a/lib/TestRunnerBase.py
+++ b/lib/TestRunnerBase.py
@@ -139,7 +139,7 @@ class TestRunnerBase(object):
         return []
 
     def __get_coverage_packages_opt(self):
-        with open('.coverage.cfg', 'r') as f:
+        with open('tests/coverage.json', 'r') as f:
             coverage_info = json.load(f)
 
         python_ver = "python{a}.{i}".format(a=sys.version_info.major,

--- a/lib/TestRunnerBase.py
+++ b/lib/TestRunnerBase.py
@@ -153,7 +153,6 @@ class TestRunnerBase(object):
         return coverage_opts.split()
 
     def __collect_coverage(self):
-        print("xxx __collect_coverage() xxx")
         with open('tests/coverage.json', 'r') as f:
             coverage_info = json.load(f)
 
@@ -162,8 +161,8 @@ class TestRunnerBase(object):
 
         path = os.path.join(sys.prefix, 'lib', python_ver, 'site-packages')
         for pkg in coverage_info["include"]:
-            pkg_files = os.path.join(path, pkg, '*')
-            cmd = "coverage report {path}".format(path=pkg_files)
+            pkg_files = glob.glob(os.path.join(path, pkg))
+            cmd = "coverage report {path}".format(path=" ".join(pkg_files))
             self.__run_cmd(cmd)
 
     def __do_run_tests(self, test_names):

--- a/lib/TestRunnerBase.py
+++ b/lib/TestRunnerBase.py
@@ -161,7 +161,7 @@ class TestRunnerBase(object):
 
         path = os.path.join(sys.prefix, 'lib', python_ver, 'site-packages')
         for pkg in coverage_info["include"]:
-            pkg_files = glob.glob(os.path.join(path, pkg, "*"))
+            pkg_files = glob.glob(os.path.join(path, pkg, "*.py"))
             cmd = "coverage report {path}".format(path=" ".join(pkg_files))
             self.__run_cmd(cmd)
             print("----------------------------------------------------------")

--- a/lib/TestRunnerBase.py
+++ b/lib/TestRunnerBase.py
@@ -148,7 +148,7 @@ class TestRunnerBase(object):
         path = os.path.join(sys.prefix, 'lib', python_ver, 'site-packages')
         for pkg in coverage_info["include"]:
             opt = "--cover-package {p}".format(p=os.path.join(path, pkg))
-            coverage_opts = coverage_opts.append(opt)
+            coverage_opts += opt
         return coverage_opts
 
     def __do_run_tests(self, test_names):

--- a/lib/TestRunnerBase.py
+++ b/lib/TestRunnerBase.py
@@ -74,7 +74,7 @@ class TestRunnerBase(object):
             download_sample_data_files(
                 test_data_files_info, get_sampledata_path())
 
-    def _get_tests(self, tests=None):
+    def _get_tests(self, workdir, tests=None):
         """
         get_tests() gets the list of test names to run.
         If <failed_only> is False, returns the set of the specified
@@ -87,7 +87,8 @@ class TestRunnerBase(object):
         """
         if tests is None or len(tests) == 0:
             # run all tests
-            test_names = glob.glob("tests/test_*py")
+            # test_names = glob.glob("tests/test_*py")
+            test_names = glob.glob(os.path.join(workdir, 'tests', '*.py')
         else:
             test_names = set(tests)
 
@@ -394,7 +395,7 @@ class TestRunnerBase(object):
         tests  : a space separated list of test cases
         """
         os.chdir(workdir)
-        test_names = self._get_tests(self.args.tests)
+        test_names = self._get_tests(workdir, self.args.tests)
 
         if self.args.checkout_baseline:
             ret_code = self._get_baseline(workdir)

--- a/lib/TestRunnerBase.py
+++ b/lib/TestRunnerBase.py
@@ -164,6 +164,7 @@ class TestRunnerBase(object):
             pkg_files = glob.glob(os.path.join(path, pkg, "*"))
             cmd = "coverage report {path}".format(path=" ".join(pkg_files))
             self.__run_cmd(cmd)
+            print("----------------------------------------------------------")
 
     def __do_run_tests(self, test_names):
         ret_code = SUCCESS

--- a/lib/TestRunnerBase.py
+++ b/lib/TestRunnerBase.py
@@ -147,8 +147,10 @@ class TestRunnerBase(object):
         coverage_opts = []
         path = os.path.join(sys.prefix, 'lib', python_ver, 'site-packages')
         for pkg in coverage_info["include"]:
-            opt = "--cover-package {p}".format(p=os.path.join(path, pkg))
-            coverage_opts.append(opt)
+            # opt = "--cover-package {p}".format(p=os.path.join(path, pkg))
+            # coverage_opts.append(opt)
+            coverage_opts.append("--cover-package")
+            coverage_opts.append(os.path.join(path, pkg))
         return coverage_opts
 
     def __do_run_tests(self, test_names):

--- a/lib/TestRunnerBase.py
+++ b/lib/TestRunnerBase.py
@@ -8,6 +8,8 @@ import codecs
 import time
 import webbrowser
 import cdp
+import json
+
 from .Util import run_command, download_sample_data_files
 from .Util import get_sampledata_path, run_nose
 from .image_compare import script_data
@@ -149,19 +151,6 @@ class TestRunnerBase(object):
             coverage_opts = coverage_opts.append(opt)
         return coverage_opts
 
-    def __get_coverage_packages_TO_BE_REMOVED(self):
-        pkgs = ["cdms2", "cdutil", "genutil", "wk", "pcmdi_metrics",
-                "vcs", "vcsaddons", "thermo", "dv3d"]
-        python_ver = "python{a}.{i}".format(a=sys.version_info.major,
-                                            i=sys.version_info.minor)
-        coverage_opts = ""
-        path = os.path.join(sys.prefix, 'lib', python_ver, 'site-packages')
-        for pkg in pkgs:
-            opt = "--cover-package {p}".format(p=os.path.join(path, pkg))
-            coverage_opts = "{curr} {new}".format(curr=coverage_opts,
-                                                  new=opt)
-        return coverage_opts.split()
-
     def __do_run_tests(self, test_names):
         ret_code = SUCCESS
         if self.args.coverage:
@@ -173,8 +162,8 @@ class TestRunnerBase(object):
         if self.args.coverage:
             coverage_opts = self.__get_coverage_packages_opt()
             opts += ["--with-coverage", "--cover-html"]
+            opts += coverage_opts
         for att in self.args.attributes:
-            opts += coverage_opts 
             opts += ["-A", att]
         func = partial(run_nose, opts, self.verbosity)
         try:

--- a/lib/TestRunnerBase.py
+++ b/lib/TestRunnerBase.py
@@ -152,6 +152,19 @@ class TestRunnerBase(object):
                                                   new=opt)
         return coverage_opts.split()
 
+    def __collect_coverage(self):
+        with open('tests/coverage.json', 'r') as f:
+            coverage_info = json.load(f)
+
+        python_ver = "python{a}.{i}".format(a=sys.version_info.major,
+                                            i=sys.version_info.minor)
+
+        path = os.path.join(sys.prefix, 'lib', python_ver, 'site-packages')
+        for pkg in coverage_info["include"]:
+            pkg_files = os.path.join(path, pkg, '*')
+            cmd = "coverage report {path}".format(path=pkg_files)
+            self.__run_cmd(cmd)
+
     def __do_run_tests(self, test_names):
         ret_code = SUCCESS
         if self.args.coverage:
@@ -201,6 +214,10 @@ class TestRunnerBase(object):
         self.results = results
         if len(failed) > 0:
             ret_code = FAILURE
+
+        if self.args.coverage:
+            self.__collect_coverage()
+
         return ret_code
 
     def __abspath(self, path, name, prefix):

--- a/lib/TestRunnerBase.py
+++ b/lib/TestRunnerBase.py
@@ -88,7 +88,7 @@ class TestRunnerBase(object):
         if tests is None or len(tests) == 0:
             # run all tests
             # test_names = glob.glob("tests/test_*py")
-            test_names = glob.glob(os.path.join(workdir, 'tests', '*.py'))
+            test_names = glob.glob("{w}/tests/test_*py".format(w=workdir))
         else:
             test_names = set(tests)
 

--- a/lib/Util.py
+++ b/lib/Util.py
@@ -25,6 +25,7 @@ def run_command(command, join_stderr=True, verbosity=2):
     out = []
     while P.poll() is None:
         read = P.stdout.readline().rstrip()
+        print("xxx read: {read}".format(read=read))
         decoded_str = read.decode('utf-8')
         out.append(str(decoded_str))
         if verbosity > 1 and len(read) != 0:

--- a/lib/Util.py
+++ b/lib/Util.py
@@ -9,7 +9,7 @@ import requests
 SUCCESS = 0
 
 
-def run_command(command, join_stderr=True, verbosity=2):
+def run_command(command, join_stderr=True, verbosity=2, popen_bufsize=0):
 
     if isinstance(command, str):
         command = shlex.split(command)
@@ -21,11 +21,10 @@ def run_command(command, join_stderr=True, verbosity=2):
         stderr = subprocess.PIPE
 
     P = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=stderr,
-                         bufsize=1, cwd=os.getcwd())
+                         bufsize=popen_bufsize, cwd=os.getcwd())
     out = []
     while P.poll() is None:
         read = P.stdout.readline().rstrip()
-        print("xxx read: {read}".format(read=read))
         decoded_str = read.decode('utf-8')
         out.append(str(decoded_str))
         if verbosity > 1 and len(read) != 0:

--- a/lib/Util.py
+++ b/lib/Util.py
@@ -21,7 +21,7 @@ def run_command(command, join_stderr=True, verbosity=2):
         stderr = subprocess.PIPE
 
     P = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=stderr,
-                         bufsize=0, cwd=os.getcwd())
+                         bufsize=1, cwd=os.getcwd())
     out = []
     while P.poll() is None:
         read = P.stdout.readline().rstrip()


### PR DESCRIPTION
when run_tests.py is run with -c option, TestRunnerBase will run nosetests with --with-coverage --cover-html and --cover-package for each package being instrumented.
Each project needs to have coverage.json file under tests directory which specifies packages that we want to get coverage on (i.e. packages that are being imported by the test cases).

For ex: cdutil's tests/coverage.json may look as follows:
{
   "include": ["cdutil", "cdms2", "genutil", "cdat_info", "testsrunner"]
}

genutil's tests/coverage.json may look as follows:
{
   "include": ["cdms2", "genutil", "cdtime", "cdat_info", "testsrunner"]
}