### PR TITLE
update to TestRunnerBase so that we can support --subdir option 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ aliases:
   - &conda_upload
     name: conda_upload
     command: |
-       if [[ $CIRCLE_BRANCH != 'revisit_run_tests' ]]; then
+       if [[ $CIRCLE_BRANCH != 'master' ]]; then
           exit 0
        fi
        export PATH=${HOME}/project/$WORKDIR/miniconda/bin:$PATH
@@ -65,8 +65,8 @@ aliases:
        export PKG_NAME=testsrunner
        export USER=cdat
        export VERSION=8.0
-       export LABEL=linatestsubdir
-       python ./prep_for_build.py -l $VERSION -b revisit_run_tests 
+       export LABEL=nightly
+       python ./prep_for_build.py -l $VERSION
        conda build $PKG_NAME -c cdat/label/nightly -c conda-forge -c cdat --python=2.7
        conda build $PKG_NAME -c cdat/label/nightly -c conda-forge -c cdat --python=3.6
        anaconda -t $CONDA_UPLOAD_TOKEN upload -u $USER -l $LABEL $CONDA_BLD_PATH/$OS/$PKG_NAME-$VERSION.`date +%Y*`0.tar.bz2 --force

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ aliases:
   - &conda_upload
     name: conda_upload
     command: |
-       if [[ $CIRCLE_BRANCH != 'master' ]]; then
+       if [[ $CIRCLE_BRANCH != 'revisit_run_tests' ]]; then
           exit 0
        fi
        export PATH=${HOME}/project/$WORKDIR/miniconda/bin:$PATH
@@ -65,8 +65,8 @@ aliases:
        export PKG_NAME=testsrunner
        export USER=cdat
        export VERSION=8.0
-       export LABEL=nightly
-       python ./prep_for_build.py -l $VERSION 
+       export LABEL=linatestsubdir
+       python ./prep_for_build.py -l $VERSION -b revisit_run_tests 
        conda build $PKG_NAME -c cdat/label/nightly -c conda-forge -c cdat --python=2.7
        conda build $PKG_NAME -c cdat/label/nightly -c conda-forge -c cdat --python=3.6
        anaconda -t $CONDA_UPLOAD_TOKEN upload -u $USER -l $LABEL $CONDA_BLD_PATH/$OS/$PKG_NAME-$VERSION.`date +%Y*`0.tar.bz2 --force

--- a/lib/TestRunnerBase.py
+++ b/lib/TestRunnerBase.py
@@ -84,7 +84,7 @@ class TestRunnerBase(object):
         the set of failed test names that is listed in <tests>
         """
         if tests is None or len(tests) == 0:
-            # run all tests
+            # get all test names
             test_names = glob.glob("{w}/tests/test_*py".format(w=workdir))
         else:
             test_names = set(tests)

--- a/lib/TestRunnerBase.py
+++ b/lib/TestRunnerBase.py
@@ -72,7 +72,7 @@ class TestRunnerBase(object):
             download_sample_data_files(
                 test_data_files_info, get_sampledata_path())
 
-    def __get_tests(self, tests=None):
+    def _get_tests(self, workdir, tests=None):
         """
         get_tests() gets the list of test names to run.
         If <failed_only> is False, returns the set of the specified
@@ -85,7 +85,7 @@ class TestRunnerBase(object):
         """
         if tests is None or len(tests) == 0:
             # run all tests
-            test_names = glob.glob("tests/test_*py")
+            test_names = glob.glob("{w}/tests/test_*py".format(w=workdir))
         else:
             test_names = set(tests)
 
@@ -102,7 +102,7 @@ class TestRunnerBase(object):
 
         return test_names
 
-    def __get_baseline(self, workdir):
+    def _get_baseline(self, workdir):
         """
         __get_baseline(self, workdir):
         <workdir> : should be repo dir of the test
@@ -136,7 +136,7 @@ class TestRunnerBase(object):
         """Place holder extend this if you want more options"""
         return []
 
-    def __do_run_tests(self, test_names):
+    def _do_run_tests(self, workdir, test_names):
         ret_code = SUCCESS
         p = multiprocessing.Pool(self.ncpus)
         # Let's prep the options once and for all
@@ -255,7 +255,7 @@ class TestRunnerBase(object):
         print("<tfoot><tr><th>Test</th><th>Result</th><th>Start Time</th>"
               "<th>End Time</th><th>Time</th></tr></tfoot>", file=fh)
 
-    def __generate_html(self, workdir, image_difference=True):
+    def _generate_html(self, workdir, image_difference=True):
         os.chdir(workdir)
         if not os.path.exists("tests_html"):
             os.makedirs("tests_html")
@@ -334,7 +334,7 @@ class TestRunnerBase(object):
         os.chdir(workdir)
         webbrowser.open("file://%s/tests_html/index.html" % workdir)
 
-    def __package_results(self, workdir):
+    def _package_results(self, workdir):
         os.chdir(workdir)
         import tarfile
         tnm = "results_%s_%s_%s.tar.bz2" % (
@@ -355,19 +355,19 @@ class TestRunnerBase(object):
         tests  : a space separated list of test cases
         """
         os.chdir(workdir)
-        test_names = self.__get_tests(self.args.tests)
+        test_names = self._get_tests(workdir, self.args.tests)
 
         if self.args.checkout_baseline:
-            ret_code = self.__get_baseline(workdir)
+            ret_code = self._get_baseline(workdir)
             if ret_code != SUCCESS:
                 return(ret_code)
 
-        ret_code = self.__do_run_tests(test_names)
+        ret_code = self._do_run_tests(workdir, test_names)
 
         if self.args.html or self.args.package:
-            self.__generate_html(workdir)
+            self._generate_html(workdir)
 
         if self.args.package:
-            self.__package_results(workdir)
+            self._package_results(workdir)
 
         return ret_code


### PR DESCRIPTION
I need to subclass TestRunnerBase for cdms so that we can add --subdir option.
Here is my cdms' run_tests.py for testing the update to TestRunnerBase.

import os
import sys
import cdat_info
import tempfile

class CDMSTestRunner(cdat_info.TestRunnerBase):
    def run(self, workdir, tests=None):

        os.chdir(workdir)
        test_names = super(CDMSTestRunner, self)._get_tests(workdir, self.args.tests)

        if self.args.checkout_baseline:
            ret_code = super(CDMSTestRunner, self)._get_baseline(workdir)
            if ret_code != SUCCESS:
                return(ret_code)

        if self.args.subdir:
            tmpdir = tempfile.mkdtemp()
            os.chdir(tmpdir)
            ret_code = super(CDMSTestRunner, self)._do_run_tests(workdir, test_names)
            os.chdir(workdir)

        if self.args.html or self.args.package:
            super(CDMSTestRunner, self)._generate_html(workdir)

        if self.args.package:
            super(CDMSTestRunner, self)._package_results(workdir)

        return ret_code


test_suite_name = 'cdms'

workdir = os.getcwd()
runner = CDMSTestRunner(test_suite_name, options=["--subdir"],
                        options_files=["tests/cdms_runtests.json"],
                        get_sample_data=True,
                        test_data_files_info="share/test_data_files.txt")
ret_code = runner.run(workdir)

sys.exit(ret_code)
