### PR TITLE
Add coverage support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,16 +12,6 @@ aliases:
       git clone -b validateNightly git@github.com:CDAT/cdat workspace/cdat
       python workspace/cdat/scripts/install_miniconda.py -w $WORKDIR -p 'py3'
 
-  - &create_conda_env_ORIG
-    name: create_conda_env_ORIG
-    command: |
-       export PATH=$WORKDIR/miniconda/bin:$PATH
-       conda config --set always_yes yes --set changeps1 no
-       conda update -y -q conda
-       conda config --set anaconda_upload no
-       conda create -q -n py2 -c cdat/label/nightly -c conda-forge -c cdat requests cdp flake8 nose python=2
-       conda create -q -n py3 -c cdat/label/nightly -c conda-forge -c cdat requests cdp flake8 nose python=3 coverage coveralls
-
   - &create_conda_env
     name: create_conda_env
     command: |
@@ -36,16 +26,6 @@ aliases:
           conda create -q -n py3 -c cdat/label/nightly -c conda-forge -c cdat requests cdp flake8 nose python=3 coverage coveralls
        fi
 
-  - &setup_testsrunner_ORIG
-    name: setup_testsrunner_ORIG
-    command: |
-       export PATH=$WORKDIR/miniconda/bin:$PATH
-       export UVCDAT_ANONYMOUS_LOG=False
-       source activate py2
-       python setup.py install
-       source activate py3
-       python setup.py install
-
   - &setup_testsrunner
     name: setup_testsrunner
     command: |
@@ -53,25 +33,6 @@ aliases:
        export UVCDAT_ANONYMOUS_LOG=False
        source activate $PY_VER
        python setup.py install
-
-
-  - &run_tests_ORIG
-    name: run_tests_ORIG
-    command: |
-       export PATH=$WORKDIR/miniconda/bin:$PATH
-       export UVCDAT_ANONYMOUS_LOG=False
-       export UVCDAT_SETUP_PATH=${HOME}
-       source activate py2
-       python run_tests.py -H -v2 -n 2
-       RESULT=$?
-       echo "*** py2 test result: "${RESULT} 
-       source activate py3
-       python run_tests.py -H -v2 -n 2 $COVERAGE
-       PY3_RESULT=$?
-       echo "**** py3 test result: "${PY3_RESULT}
-       RESULT=$(( $RESULT + $PY3_RESULT))
-       exit $RESULT
-
 
   - &run_tests
     name: run_tests
@@ -93,7 +54,7 @@ aliases:
   - &conda_upload
     name: conda_upload
     command: |
-       if [[ $CIRCLE_BRANCH != 'add_coverage' ]]; then
+       if [[ $CIRCLE_BRANCH != 'master' ]]; then
           exit 0
        fi
        export PATH=${HOME}/project/$WORKDIR/miniconda/bin:$PATH
@@ -105,8 +66,8 @@ aliases:
        export PKG_NAME=testsrunner
        export USER=cdat
        export VERSION=8.0
-       export LABEL=linatest
-       python ./prep_for_build.py -l $VERSION -b 'add_coverage'
+       export LABEL=nightly
+       python ./prep_for_build.py -l $VERSION
        conda build $PKG_NAME -c cdat/label/nightly -c conda-forge -c cdat --python=2.7
        conda build $PKG_NAME -c cdat/label/nightly -c conda-forge -c cdat --python=3.6
        anaconda -t $CONDA_UPLOAD_TOKEN upload -u $USER -l $LABEL $CONDA_BLD_PATH/$OS/$PKG_NAME-$VERSION.`date +%Y*`0.tar.bz2 --force
@@ -190,28 +151,6 @@ jobs:
       WORKDIR: "workspace/test_linux_testsrunner"
       OS: "linux-64"
       PY_VER: "py3"
-      COVERAGE: "-c tests/coverage.json"
-    steps:
-      - checkout
-      - run: *setup_miniconda
-      - run: *create_conda_env
-      - run: *setup_testsrunner
-      - run: *run_tests
-      - run: *run_coveralls
-      - run: *conda_upload
-      - store_artifacts:
-          path: tests_html
-          destination: tests_html
-      - store_artifacts:
-          path: tests_png
-          destination: tests_png
-
-  linux_testsrunner_ORIG:
-    machine:
-      image: circleci/classic:latest
-    environment:
-      WORKDIR: "workspace/test_linux_testsrunner"
-      OS: "linux-64"
       COVERAGE: "-c tests/coverage.json"
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ aliases:
        RESULT=$?
        echo "*** py2 test result: "${RESULT} 
        source activate py3
-       python run_tests.py -H -v2 -n 2 -c
+       python run_tests.py -H -v2 -n 2 -c tests/coverage.json
        PY3_RESULT=$?
        echo "**** py3 test result: "${PY3_RESULT}
        RESULT=$(( $RESULT + $PY3_RESULT))

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,8 +68,11 @@ aliases:
        export VERSION=8.0
        export LABEL=nightly
        python ./prep_for_build.py -l $VERSION
-       conda build $PKG_NAME -c cdat/label/nightly -c conda-forge -c cdat --python=2.7
-       conda build $PKG_NAME -c cdat/label/nightly -c conda-forge -c cdat --python=3.6
+       if [ $PY_VER = 'py2' ] then
+          conda build $PKG_NAME -c cdat/label/nightly -c conda-forge -c cdat --python=2.7
+       else
+          conda build $PKG_NAME -c cdat/label/nightly -c conda-forge -c cdat --python=3.6
+       fi
        anaconda -t $CONDA_UPLOAD_TOKEN upload -u $USER -l $LABEL $CONDA_BLD_PATH/$OS/$PKG_NAME-$VERSION.`date +%Y*`0.tar.bz2 --force
 
   - &run_coveralls

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ aliases:
   - &conda_upload
     name: conda_upload
     command: |
-       if [[ $CIRCLE_BRANCH != 'master' ]]; then
+       if [[ $CIRCLE_BRANCH != 'add_coverage' ]]; then
           exit 0
        fi
        export PATH=${HOME}/project/$WORKDIR/miniconda/bin:$PATH
@@ -65,8 +65,8 @@ aliases:
        export PKG_NAME=testsrunner
        export USER=cdat
        export VERSION=8.0
-       export LABEL=nightly
-       python ./prep_for_build.py -l $VERSION
+       export LABEL=linatest
+       python ./prep_for_build.py -l $VERSION -b 'add_coverage'
        conda build $PKG_NAME -c cdat/label/nightly -c conda-forge -c cdat --python=2.7
        conda build $PKG_NAME -c cdat/label/nightly -c conda-forge -c cdat --python=3.6
        anaconda -t $CONDA_UPLOAD_TOKEN upload -u $USER -l $LABEL $CONDA_BLD_PATH/$OS/$PKG_NAME-$VERSION.`date +%Y*`0.tar.bz2 --force

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ aliases:
        conda config --set always_yes yes --set changeps1 no
        conda update -y -q conda
        conda config --set anaconda_upload no
-       if [ $PY_VERSION = "py2" ]
+       if [ $PY_VER = "py2" ]
        then
           conda create -q -n py2 -c cdat/label/nightly -c conda-forge -c cdat requests cdp flake8 nose python=2
        else
@@ -51,7 +51,7 @@ aliases:
     command: |
        export PATH=$WORKDIR/miniconda/bin:$PATH
        export UVCDAT_ANONYMOUS_LOG=False
-       source activate $PY_VERSION
+       source activate $PY_VER
        python setup.py install
 
 
@@ -79,15 +79,15 @@ aliases:
        export PATH=$WORKDIR/miniconda/bin:$PATH
        export CDAT_ANONYMOUS_LOG=False
        export CDAT_SETUP_PATH=${HOME}
-       source activate $PY_VERSION
-       if [ $PY_VERSION = 'py2' ]
+       source activate $PY_VER
+       if [ $PY_VER = 'py2' ]
        then
           python run_tests.py -H -v2 -n 2
        else
           python run_tests.py -H -v2 -n 2 $COVERAGE
        fi
        RESULT=$?
-       echo "*** $PY_VERSION test result: "${RESULT} 
+       echo "*** $PY_VER test result: "${RESULT} 
        exit $RESULT
 
 
@@ -121,30 +121,19 @@ aliases:
        source deactivate
 
 jobs:
-  macos_testsrunner:
+  macos_testsrunner_py2:
     macos:
       xcode: "9.2.0"
     environment:
       WORKDIR: "workspace/test_macos_testsrunner"
       OS: "osx-64"
+      PY_VER: "py2"
     steps:
       - checkout
-      - run: 
-           environment: 
-              PY_VERSION: "py2"
-           command: |
-              *setup_miniconda
-              *create_conda_env
-              *setup_testsrunner
-              *run_tests
-      - run: 
-           environment: 
-              PY_VERSION: "py3"
-           command: |
-              *setup_miniconda
-              *create_conda_env
-              *setup_testsrunner
-              *run_tests
+      - run: *setup_miniconda
+      - run: *create_conda_env
+      - run: *setup_testsrunner
+      - run: *run_tests
       - run: *conda_upload
       - store_artifacts:
           path: tests_html
@@ -153,32 +142,62 @@ jobs:
           path: tests_png
           destination: tests_png
 
-  linux_testsrunner:
+  macos_testsrunner_py3:
+    macos:
+      xcode: "9.2.0"
+    environment:
+      WORKDIR: "workspace/test_macos_testsrunner"
+      OS: "osx-64"
+      PY_VER: "py3"
+    steps:
+      - checkout
+      - run: *setup_miniconda
+      - run: *create_conda_env
+      - run: *setup_testsrunner
+      - run: *run_tests
+      - run: *conda_upload
+      - store_artifacts:
+          path: tests_html
+          destination: tests_html
+      - store_artifacts:
+          path: tests_png
+          destination: tests_png
+
+  linux_testsrunner_py2:
     machine:
       image: circleci/classic:latest
     environment:
       WORKDIR: "workspace/test_linux_testsrunner"
       OS: "linux-64"
+      PY_VER: "py2"
+    steps:
+      - checkout
+      - run: *setup_miniconda
+      - run: *create_conda_env
+      - run: *setup_testsrunner
+      - run: *run_tests
+      - run: *conda_upload
+      - store_artifacts:
+          path: tests_html
+          destination: tests_html
+      - store_artifacts:
+          path: tests_png
+          destination: tests_png
+
+  linux_testsrunner_py3:
+    machine:
+      image: circleci/classic:latest
+    environment:
+      WORKDIR: "workspace/test_linux_testsrunner"
+      OS: "linux-64"
+      PY_VER: "py3"
       COVERAGE: "-c tests/coverage.json"
     steps:
       - checkout
       - run: *setup_miniconda
-      - run: 
-           environment: 
-              PY_VERSION: "py2"
-           command: |
-              *setup_miniconda
-              *create_conda_env
-              *setup_testsrunner
-              *run_tests
-      - run: 
-           environment: 
-              PY_VERSION: "py3"
-           command: |
-              *setup_miniconda
-              *create_conda_env
-              *setup_testsrunner
-              *run_tests
+      - run: *create_conda_env
+      - run: *setup_testsrunner
+      - run: *run_tests
       - run: *run_coveralls
       - run: *conda_upload
       - store_artifacts:
@@ -210,10 +229,16 @@ jobs:
           path: tests_png
           destination: tests_png
 
-
 workflows:
   version: 2
   testsrunner:
     jobs:
-      - macos_testsrunner
-      - linux_testsrunner
+      - macos_testsrunner_py2
+      - macos_testsrunner_py3:
+           requires:
+              - macos_testsrunner_py2
+      - linux_testsrunner_py2
+      - linux_testsrunner_py3:
+           requires:
+              - linux_testsrunner_py2
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,8 +88,7 @@ aliases:
        fi
        RESULT=$?
        echo "*** $PY_VER test result: "${RESULT} 
-       # exit $RESULT
-       exit 1
+       exit $RESULT
 
   - &conda_upload
     name: conda_upload

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,13 +129,22 @@ jobs:
       OS: "osx-64"
     steps:
       - checkout
-      - run: *setup_miniconda
-      - run: PY_VERSION="py2" *create_conda_env
-      - run: PY_VERSION="py2" *setup_testsrunner
-      - run: PY_VERSION="py2" *run_tests
-      - run: PY_VERSION="py3" *create_conda_env
-      - run: PY_VERSION="py3" *setup_testsrunner
-      - run: PY_VERSION="py3" *run_tests
+      - run: 
+           environment: 
+              PY_VERSION: "py2"
+           command: |
+              *setup_miniconda
+              *create_conda_env
+              *setup_testsrunner
+              *run_tests
+      - run: 
+           environment: 
+              PY_VERSION: "py3"
+           command: |
+              *setup_miniconda
+              *create_conda_env
+              *setup_testsrunner
+              *run_tests
       - run: *conda_upload
       - store_artifacts:
           path: tests_html
@@ -154,12 +163,22 @@ jobs:
     steps:
       - checkout
       - run: *setup_miniconda
-      - run: PY_VERSION="py2" *create_conda_env
-      - run: PY_VERSION="py2" *setup_testsrunner
-      - run: PY_VERSION="py2" *run_tests
-      - run: PY_VERSION="py3" *create_conda_env
-      - run: PY_VERSION="py3" *setup_testsrunner
-      - run: PY_VERSION="py3" *run_tests
+      - run: 
+           environment: 
+              PY_VERSION: "py2"
+           command: |
+              *setup_miniconda
+              *create_conda_env
+              *setup_testsrunner
+              *run_tests
+      - run: 
+           environment: 
+              PY_VERSION: "py3"
+           command: |
+              *setup_miniconda
+              *create_conda_env
+              *setup_testsrunner
+              *run_tests
       - run: *run_coveralls
       - run: *conda_upload
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,8 +88,8 @@ aliases:
        fi
        RESULT=$?
        echo "*** $PY_VER test result: "${RESULT} 
-       exit $RESULT
-
+       # exit $RESULT
+       exit 1
 
   - &conda_upload
     name: conda_upload

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ aliases:
   - &conda_upload
     name: conda_upload
     command: |
-       if [[ $CIRCLE_BRANCH != 'add_coverage' ]]; then
+       if [[ $CIRCLE_BRANCH != 'master' ]]; then
           exit 0
        fi
        export PATH=${HOME}/project/$WORKDIR/miniconda/bin:$PATH
@@ -65,8 +65,8 @@ aliases:
        export PKG_NAME=testsrunner
        export USER=cdat
        export VERSION=8.0
-       export LABEL=linatest
-       python ./prep_for_build.py -l $VERSION -b 'add_coverage'
+       export LABEL=nightly
+       python ./prep_for_build.py -l $VERSION
        conda build $PKG_NAME -c cdat/label/nightly -c conda-forge -c cdat --python=2.7
        conda build $PKG_NAME -c cdat/label/nightly -c conda-forge -c cdat --python=3.6
        anaconda -t $CONDA_UPLOAD_TOKEN upload -u $USER -l $LABEL $CONDA_BLD_PATH/$OS/$PKG_NAME-$VERSION.`date +%Y*`0.tar.bz2 --force

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ aliases:
        conda update -y -q conda
        conda config --set anaconda_upload no
        conda create -q -n py2 -c cdat/label/nightly -c conda-forge -c cdat requests cdp flake8 nose python=2
-       conda create -q -n py3 -c cdat/label/nightly -c conda-forge -c cdat requests cdp flake8 nose python=3
+       conda create -q -n py3 -c cdat/label/nightly -c conda-forge -c cdat requests cdp flake8 nose python=3 coverage coveralls
 
   - &setup_testsrunner
     name: setup_testsrunner
@@ -43,7 +43,7 @@ aliases:
        RESULT=$?
        echo "*** py2 test result: "${RESULT} 
        source activate py3
-       python run_tests.py -H -v2 -n 2
+       python run_tests.py -H -v2 -n 2 -c
        PY3_RESULT=$?
        echo "**** py3 test result: "${PY3_RESULT}
        RESULT=$(( $RESULT + $PY3_RESULT))

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,8 +12,8 @@ aliases:
       git clone -b validateNightly git@github.com:CDAT/cdat workspace/cdat
       python workspace/cdat/scripts/install_miniconda.py -w $WORKDIR -p 'py3'
 
-  - &create_conda_env
-    name: create_conda_env
+  - &create_conda_env_ORIG
+    name: create_conda_env_ORIG
     command: |
        export PATH=$WORKDIR/miniconda/bin:$PATH
        conda config --set always_yes yes --set changeps1 no
@@ -22,8 +22,22 @@ aliases:
        conda create -q -n py2 -c cdat/label/nightly -c conda-forge -c cdat requests cdp flake8 nose python=2
        conda create -q -n py3 -c cdat/label/nightly -c conda-forge -c cdat requests cdp flake8 nose python=3 coverage coveralls
 
-  - &setup_testsrunner
-    name: setup_testsrunner
+  - &create_conda_env
+    name: create_conda_env
+    command: |
+       export PATH=$WORKDIR/miniconda/bin:$PATH
+       conda config --set always_yes yes --set changeps1 no
+       conda update -y -q conda
+       conda config --set anaconda_upload no
+       if [ $PY_VERSION = "py2" ]
+       then
+          conda create -q -n py2 -c cdat/label/nightly -c conda-forge -c cdat requests cdp flake8 nose python=2
+       else
+          conda create -q -n py3 -c cdat/label/nightly -c conda-forge -c cdat requests cdp flake8 nose python=3 coverage coveralls
+       fi
+
+  - &setup_testsrunner_ORIG
+    name: setup_testsrunner_ORIG
     command: |
        export PATH=$WORKDIR/miniconda/bin:$PATH
        export UVCDAT_ANONYMOUS_LOG=False
@@ -32,8 +46,17 @@ aliases:
        source activate py3
        python setup.py install
 
-  - &run_tests
-    name: run_tests
+  - &setup_testsrunner
+    name: setup_testsrunner
+    command: |
+       export PATH=$WORKDIR/miniconda/bin:$PATH
+       export UVCDAT_ANONYMOUS_LOG=False
+       source activate $PY_VERSION
+       python setup.py install
+
+
+  - &run_tests_ORIG
+    name: run_tests_ORIG
     command: |
        export PATH=$WORKDIR/miniconda/bin:$PATH
        export UVCDAT_ANONYMOUS_LOG=False
@@ -43,10 +66,28 @@ aliases:
        RESULT=$?
        echo "*** py2 test result: "${RESULT} 
        source activate py3
-       python run_tests.py -H -v2 -n 2 -c tests/coverage.json
+       python run_tests.py -H -v2 -n 2 $COVERAGE
        PY3_RESULT=$?
        echo "**** py3 test result: "${PY3_RESULT}
        RESULT=$(( $RESULT + $PY3_RESULT))
+       exit $RESULT
+
+
+  - &run_tests
+    name: run_tests
+    command: |
+       export PATH=$WORKDIR/miniconda/bin:$PATH
+       export CDAT_ANONYMOUS_LOG=False
+       export CDAT_SETUP_PATH=${HOME}
+       source activate $PY_VERSION
+       if [ $PY_VERSION = 'py2' ]
+       then
+          python run_tests.py -H -v2 -n 2
+       else
+          python run_tests.py -H -v2 -n 2 $COVERAGE
+       fi
+       RESULT=$?
+       echo "*** $PY_VERSION test result: "${RESULT} 
        exit $RESULT
 
 
@@ -71,6 +112,14 @@ aliases:
        conda build $PKG_NAME -c cdat/label/nightly -c conda-forge -c cdat --python=3.6
        anaconda -t $CONDA_UPLOAD_TOKEN upload -u $USER -l $LABEL $CONDA_BLD_PATH/$OS/$PKG_NAME-$VERSION.`date +%Y*`0.tar.bz2 --force
 
+  - &run_coveralls
+    name: run_coveralls
+    command: |
+       export PATH=$WORKDIR/miniconda/bin:$PATH
+       source activate py3
+       coveralls
+       source deactivate
+
 jobs:
   macos_testsrunner:
     macos:
@@ -81,9 +130,12 @@ jobs:
     steps:
       - checkout
       - run: *setup_miniconda
-      - run: *create_conda_env
-      - run: *setup_testsrunner
-      - run: *run_tests
+      - run: PY_VERSION="py2" *create_conda_env
+      - run: PY_VERSION="py2" *setup_testsrunner
+      - run: PY_VERSION="py2" *run_tests
+      - run: PY_VERSION="py3" *create_conda_env
+      - run: PY_VERSION="py3" *setup_testsrunner
+      - run: PY_VERSION="py3" *run_tests
       - run: *conda_upload
       - store_artifacts:
           path: tests_html
@@ -98,12 +150,39 @@ jobs:
     environment:
       WORKDIR: "workspace/test_linux_testsrunner"
       OS: "linux-64"
+      COVERAGE: "-c tests/coverage.json"
+    steps:
+      - checkout
+      - run: *setup_miniconda
+      - run: PY_VERSION="py2" *create_conda_env
+      - run: PY_VERSION="py2" *setup_testsrunner
+      - run: PY_VERSION="py2" *run_tests
+      - run: PY_VERSION="py3" *create_conda_env
+      - run: PY_VERSION="py3" *setup_testsrunner
+      - run: PY_VERSION="py3" *run_tests
+      - run: *run_coveralls
+      - run: *conda_upload
+      - store_artifacts:
+          path: tests_html
+          destination: tests_html
+      - store_artifacts:
+          path: tests_png
+          destination: tests_png
+
+  linux_testsrunner_ORIG:
+    machine:
+      image: circleci/classic:latest
+    environment:
+      WORKDIR: "workspace/test_linux_testsrunner"
+      OS: "linux-64"
+      COVERAGE: "-c tests/coverage.json"
     steps:
       - checkout
       - run: *setup_miniconda
       - run: *create_conda_env
       - run: *setup_testsrunner
       - run: *run_tests
+      - run: *run_coveralls
       - run: *conda_upload
       - store_artifacts:
           path: tests_html

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
+# testsrunner
 
-The testsrunner module provides a modular implementation of argument parsing interfaces.
-It provides an easy way to define user friendly command line interfaces.
-It uses cdp for parsing arguments.
+The testsrunner module provides a modular implementation of argument parsing interfaces.It provides an easy way to define user friendly command line interfaces. It uses cdp for parsing arguments.
 
+# Example
 Example on how to write a runner program run_tests.py for a project / test suite
 using testsrunner:
-
+```
   $ cat run_tests.py
   import os
   import sys
@@ -17,22 +17,16 @@ using testsrunner:
   runner = TestRunnerBase(test_suite_name)
   ret_code = runner.run(workdir)
   sys.exit(ret_code)
-
-To run tests with coverage, you will need to define the packages that you
-want to collect coverage info on. Define those packages in a json file
-as follows, and pass it to the test runner run_tests.py.
-
+```
+To run tests with coverage, you will need to define the packages that you want to collect coverage info on. Define those packages in a json file as follows, and pass it to the test runner run_tests.py.
+```
   $ cat coverage.json
   {
      "include": ["testsrunner"]
   }
-
   $ run_tests.py -v 2 -H -c coverage.json
-
-If running tests from a repository, then coverage information should
-be collecting from packages in the repository:
-
+```
+If running tests from a repository, then coverage information should be collecting from packages in the repository:
+```
   $ run_tests.py -v 2 -H -c coverage.json --coverage-from-repo
-
-
-
+```

--- a/README.md
+++ b/README.md
@@ -1,0 +1,38 @@
+
+The testsrunner module provides a modular implementation of argument parsing interfaces.
+It provides an easy way to define user friendly command line interfaces.
+It uses cdp for parsing arguments.
+
+Example on how to write a runner program run_tests.py for a project / test suite
+using testsrunner:
+
+  $ cat run_tests.py
+  import os
+  import sys
+  from testsrunner import TestRunnerBase
+
+  test_suite_name = 'testsrunner'
+  workdir = os.getcwd()
+
+  runner = TestRunnerBase(test_suite_name)
+  ret_code = runner.run(workdir)
+  sys.exit(ret_code)
+
+To run tests with coverage, you will need to define the packages that you
+want to collect coverage info on. Define those packages in a json file
+as follows, and pass it to the test runner run_tests.py.
+
+  $ cat coverage.json
+  {
+     "include": ["testsrunner"]
+  }
+
+  $ run_tests.py -v 2 -H -c coverage.json
+
+If running tests from a repository, then coverage information should
+be collecting from packages in the repository:
+
+  $ run_tests.py -v 2 -H -c coverage.json --coverage-from-repo
+
+
+

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # testsrunner
 
-The testsrunner module provides a modular implementation of argument parsing interfaces.It provides an easy way to define user friendly command line interfaces. It uses cdp for parsing arguments.
+The testsrunner module provides a modular implementation of argument parsing interfaces. It provides an easy way to define user friendly command line interfaces. It uses cdp for parsing arguments.
 
 # Example
 Example on how to write a runner program run_tests.py for a project / test suite
@@ -18,15 +18,19 @@ using testsrunner:
   ret_code = runner.run(workdir)
   sys.exit(ret_code)
 ```
-To run tests with coverage, you will need to define the packages that you want to collect coverage info on. Define those packages in a json file as follows, and pass it to the test runner run_tests.py.
+To run tests with coverage, you will need to define the packages that you want to collect coverage info on. Define those packages in a json file as follows, and pass it to run_tests.py.
 ```
   $ cat coverage.json
   {
      "include": ["testsrunner"]
   }
+```
+To run tests with coverage, and collect coverage information from packages installed in the conda environment:
+```
   $ run_tests.py -v 2 -H -c coverage.json
 ```
-If running tests from a repository, then coverage information should be collecting from packages in the repository:
+To run tests with coverage, and collect coverage information from packages / modules in the repository:
+
 ```
   $ run_tests.py -v 2 -H -c coverage.json --coverage-from-repo
 ```

--- a/lib/TestRunnerBase.py
+++ b/lib/TestRunnerBase.py
@@ -24,10 +24,9 @@ class TestRunnerBase(object):
     class, and call the run() method. For example:
 
       runner = TestRunnerBase.TestRunnerBase(test_suite_name, valid_options,
-         args, get_sample_data)
+      args, get_sample_data)
       runner.run(workdir, args.tests)
     """
-
     def __init__(self, test_suite_name, options=[], options_files=[],
                  get_sample_data=False, test_data_files_info=None):
         """
@@ -60,7 +59,6 @@ class TestRunnerBase(object):
             parser.use(option)
 
         self.args = parser.get_parameter()
-        print("xxx xxx in init()...self.args.tests: {t}".format(t=self.args.tests))
         self.test_suite_name = test_suite_name
         self.verbosity = self.args.verbosity
         self.ncpus = self.args.num_workers
@@ -135,7 +133,7 @@ class TestRunnerBase(object):
         return []
 
     def __get_coverage_packages_opt(self, workdir):
-        with open(os.path.join(workdir, 'tests', 'coverage.json'), 'r') as f:
+        with open(os.path.join(workdir, self.args.coverage), 'r') as f:
             coverage_info = json.load(f)
 
         python_ver = "python{a}.{i}".format(a=sys.version_info.major,
@@ -394,10 +392,7 @@ class TestRunnerBase(object):
         if tests is None:
             test_names = self._get_tests(workdir, self.args.tests)
         else:
-            test_names = [ tests ]
-        print("xxx xxx in run()...test_names: {t}".format(t=test_names))
-        print("xxx xxx in run()...self.args.tests: {t}".format(t=self.args.tests))
-
+            test_names = [tests]
         if self.args.checkout_baseline:
             ret_code = self._get_baseline(workdir)
             if ret_code != SUCCESS:

--- a/lib/TestRunnerBase.py
+++ b/lib/TestRunnerBase.py
@@ -145,8 +145,6 @@ class TestRunnerBase(object):
             opt = "--cover-package {p}".format(p=os.path.join(path, pkg))
             coverage_opts = "{curr} {new}".format(curr=coverage_opts,
                                                   new=opt)
-        coverage_opts = "{curr} {new}".format(curr=coverage_opts,
-                                              new="--cover-inclusive")
         return coverage_opts.split()
 
     def __collect_coverage(self, workdir):

--- a/lib/TestRunnerBase.py
+++ b/lib/TestRunnerBase.py
@@ -137,12 +137,12 @@ class TestRunnerBase(object):
         with open(self.args.coverage, 'r') as f:
             coverage_info = json.load(f)
 
-        python_ver = "python{a}.{i}".format(a=sys.version_info.major,
-                                            i=sys.version_info.minor)
         coverage_opts = ""
         if self.args.coverage_from_repo:
             path = os.getcwd()
         else:
+            python_ver = "python{a}.{i}".format(a=sys.version_info.major,
+                                                i=sys.version_info.minor)
             path = os.path.join(sys.prefix, 'lib', python_ver, 'site-packages')
         for pkg in coverage_info["include"]:
             opt = "--cover-package {p}".format(p=os.path.join(path, pkg))
@@ -158,14 +158,17 @@ class TestRunnerBase(object):
         with open(os.path.join(workdir, 'tests', 'coverage.json'), 'r') as f:
             coverage_info = json.load(f)
 
-        python_ver = "python{a}.{i}".format(a=sys.version_info.major,
-                                            i=sys.version_info.minor)
-
-        path = os.path.join(sys.prefix, 'lib', python_ver, 'site-packages')
+        if self.args.coverage_from_repo:
+            path = os.getcwd()
+        else:
+            python_ver = "python{a}.{i}".format(a=sys.version_info.major,
+                                                i=sys.version_info.minor)
+            path = os.path.join(sys.prefix, 'lib', python_ver, 'site-packages')
 
         for pkg in coverage_info["include"]:
             pkg_files = glob.glob(os.path.join(path, pkg, "*.py"))
             cmd = "coverage report {path}".format(path=" ".join(pkg_files))
+
             # set popen_bufsize to 1 because some coverage output is large.
             run_command(cmd, True, 2, 1)
 

--- a/lib/TestRunnerBase.py
+++ b/lib/TestRunnerBase.py
@@ -147,6 +147,10 @@ class TestRunnerBase(object):
         return coverage_opts.split()
 
     def __collect_coverage(self, workdir):
+        coverage_files = glob.glob(".cvrg/*")
+        run_command("coverage combine {}".format(" ".join(coverage_files)))
+        run_command("coverage xml")
+        run_command("coverage html")
         with open(os.path.join(workdir, 'tests', 'coverage.json'), 'r') as f:
             coverage_info = json.load(f)
 
@@ -163,16 +167,15 @@ class TestRunnerBase(object):
 
     def _do_run_tests(self, workdir, test_names):
         ret_code = SUCCESS
-        if self.args.coverage:
-            p = multiprocessing.Pool(1)
-        else:
-            p = multiprocessing.Pool(self.ncpus)
+        p = multiprocessing.Pool(self.ncpus)
         # Let's prep the options once and for all
         opts = self._prep_nose_options()
         if self.args.coverage:
             coverage_opts = self.__get_coverage_packages_opt(workdir)
-            opts += ["--with-coverage", "--cover-html", "--cover-xml"]
+            opts += ["--with-coverage", ]
             opts += coverage_opts
+            if not os.path.exists(".cvrg"):
+                os.makedirs(".cvrg")
         for att in self.args.attributes:
             opts += ["-A", att]
         func = partial(run_nose, opts, self.verbosity)

--- a/lib/TestRunnerBase.py
+++ b/lib/TestRunnerBase.py
@@ -145,6 +145,8 @@ class TestRunnerBase(object):
             opt = "--cover-package {p}".format(p=os.path.join(path, pkg))
             coverage_opts = "{curr} {new}".format(curr=coverage_opts,
                                                   new=opt)
+        coverage_opts = "{curr} {new}".format(curr=coverage_opts,
+                                              new="--cover-inclusive")
         return coverage_opts.split()
 
     def __collect_coverage(self, workdir):

--- a/lib/TestRunnerBase.py
+++ b/lib/TestRunnerBase.py
@@ -158,7 +158,6 @@ class TestRunnerBase(object):
                                             i=sys.version_info.minor)
 
         path = os.path.join(sys.prefix, 'lib', python_ver, 'site-packages')
-        print("xxx DEBUG __collect_coverage(), path: {p}".format(p=path))
 
         for pkg in coverage_info["include"]:
             pkg_files = glob.glob(os.path.join(path, pkg, "*.py"))

--- a/lib/TestRunnerBase.py
+++ b/lib/TestRunnerBase.py
@@ -54,7 +54,8 @@ class TestRunnerBase(object):
         options += ["--coverage", "--verbosity", "--num_workers",
                     "--attributes", "--parameters", "--diags",
                     "--baseline", "--checkout-baseline",
-                    "--html", "--failed", "--package"]
+                    "--html", "--failed", "--package",
+                    "--coverage-from-repo"]
         for option in set(options):
             parser.use(option)
 
@@ -133,13 +134,16 @@ class TestRunnerBase(object):
         return []
 
     def __get_coverage_packages_opt(self, workdir):
-        with open(os.path.join(workdir, self.args.coverage), 'r') as f:
+        with open(self.args.coverage, 'r') as f:
             coverage_info = json.load(f)
 
         python_ver = "python{a}.{i}".format(a=sys.version_info.major,
                                             i=sys.version_info.minor)
         coverage_opts = ""
-        path = os.path.join(sys.prefix, 'lib', python_ver, 'site-packages')
+        if self.args.coverage_from_repo:
+            path = os.getcwd()
+        else:
+            path = os.path.join(sys.prefix, 'lib', python_ver, 'site-packages')
         for pkg in coverage_info["include"]:
             opt = "--cover-package {p}".format(p=os.path.join(path, pkg))
             coverage_opts = "{curr} {new}".format(curr=coverage_opts,

--- a/lib/TestRunnerBase.py
+++ b/lib/TestRunnerBase.py
@@ -61,11 +61,8 @@ class TestRunnerBase(object):
 
         self.args = parser.get_parameter()
         self.test_suite_name = test_suite_name
-
         self.verbosity = self.args.verbosity
-
         self.ncpus = self.args.num_workers
-
         if get_sample_data is True:
             if test_data_files_info is None:
                 test_data_files_info = os.path.join(

--- a/lib/TestRunnerBase.py
+++ b/lib/TestRunnerBase.py
@@ -60,6 +60,7 @@ class TestRunnerBase(object):
             parser.use(option)
 
         self.args = parser.get_parameter()
+        print("xxx xxx in init()...self.args.tests: {t}".format(t=self.args.tests))
         self.test_suite_name = test_suite_name
         self.verbosity = self.args.verbosity
         self.ncpus = self.args.num_workers
@@ -390,7 +391,12 @@ class TestRunnerBase(object):
         tests  : a space separated list of test cases
         """
         os.chdir(workdir)
-        test_names = self._get_tests(workdir, self.args.tests)
+        if tests is None:
+            test_names = self._get_tests(workdir, self.args.tests)
+        else:
+            test_names = [ tests ]
+        print("xxx xxx in run()...test_names: {t}".format(t=test_names))
+        print("xxx xxx in run()...self.args.tests: {t}".format(t=self.args.tests))
 
         if self.args.checkout_baseline:
             ret_code = self._get_baseline(workdir)

--- a/lib/Util.py
+++ b/lib/Util.py
@@ -21,7 +21,7 @@ def run_command(command, join_stderr=True, verbosity=2, popen_bufsize=0):
         stderr = subprocess.PIPE
 
     P = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=stderr,
-                         popen_bufsize, cwd=os.getcwd())
+                         bufsize=popen_bufsize, cwd=os.getcwd())
     out = []
     while P.poll() is None:
         read = P.stdout.readline().rstrip()

--- a/lib/Util.py
+++ b/lib/Util.py
@@ -9,7 +9,7 @@ import requests
 SUCCESS = 0
 
 
-def run_command(command, join_stderr=True, verbosity=2):
+def run_command(command, join_stderr=True, verbosity=2, popen_bufsize=0):
 
     if isinstance(command, str):
         command = shlex.split(command)
@@ -21,7 +21,7 @@ def run_command(command, join_stderr=True, verbosity=2):
         stderr = subprocess.PIPE
 
     P = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=stderr,
-                         bufsize=0, cwd=os.getcwd())
+                         popen_bufsize, cwd=os.getcwd())
     out = []
     while P.poll() is None:
         read = P.stdout.readline().rstrip()

--- a/resources/test_options_file.json
+++ b/resources/test_options_file.json
@@ -1,0 +1,10 @@
+{
+    "--stdout": {
+        "aliases": [
+            "-s"
+        ], 
+        "default": [], 
+        "help": "print stdout to console"
+    }
+}
+

--- a/resources/test_options_file.json
+++ b/resources/test_options_file.json
@@ -4,7 +4,30 @@
             "-s"
         ], 
         "default": [], 
-        "help": "print stdout to console"
+        "help": "nosetests option - print stdout to console"
+    },
+    "--with-coverage": {
+        "action": "store_true",
+        "default": false, 
+        "help": "nosetests option - run with coverage",
+	"type": null
+    },
+    "--cover-html": {
+        "action": "store_true",
+        "default": false, 
+        "help": "nosetests option - generate coverage html",
+	"type": null
+    },
+    "--cover-xml": {
+        "action": "store_true",
+        "default": false, 
+        "help": "nosetests option - generate coverage xml",
+	"type": null
+    },
+    "--cover-package": {
+        "required": false,
+        "help": "nosetests option - package to generate coverage for",
+	"type": "str"
     }
 }
 

--- a/resources/testsrunner.json
+++ b/resources/testsrunner.json
@@ -20,13 +20,12 @@
         "type": null
     }, 
     "--coverage": {
-        "action": "store_true", 
         "aliases": [
             "-c"
         ], 
-        "default": false, 
-        "help": "run nose test with coverage info", 
-        "type": null
+	"required": false,
+        "help": "run nose test with coverage for the packages specified in the json file", 
+        "type": "str"
     }, 
     "--diags": {
         "aliases": [

--- a/resources/testsrunner.json
+++ b/resources/testsrunner.json
@@ -27,6 +27,12 @@
         "help": "run nose test with coverage for the packages specified in the json file", 
         "type": "str"
     }, 
+    "--coverage-from-repo": {
+        "action": "store_true", 
+        "default": false, 
+        "help": "run tests coverage on repo files", 
+        "type": null
+    }, 
     "--diags": {
         "aliases": [
             "-d"

--- a/run_tests.py
+++ b/run_tests.py
@@ -7,6 +7,6 @@ test_suite_name = 'testsrunner'
 
 workdir = os.getcwd()
 
-runner = TestRunnerBase(test_suite_name)
+runner = TestRunnerBase(test_suite_name, test_data_files_info=os.path.join(os.path.dirname(__file__),"share", "test_data_files.txt"))
 ret_code = runner.run(workdir)
 sys.exit(ret_code)

--- a/setup.py
+++ b/setup.py
@@ -7,5 +7,5 @@ setup(name="testrunner",
       packages=['testsrunner'],
       package_dir={'testsrunner': 'lib'},
       data_files=[("share/testsrunner",
-                   ["resources/testsrunner.json", "resources/image-compare.min.js", "resources/diff.html"])],
+                   ["resources/testsrunner.json", "resources/image-compare.min.js", "resources/diff.html", "resources/test_options_file.json"])],
       )

--- a/setup.py
+++ b/setup.py
@@ -7,5 +7,5 @@ setup(name="testrunner",
       packages=['testsrunner'],
       package_dir={'testsrunner': 'lib'},
       data_files=[("share/testsrunner",
-                   ["resources/testsrunner.json", "resources/image-compare.min.js", "resources/diff.html", "resources/test_options_file.json"])],
+                   ["resources/testsrunner.json", "resources/image-compare.min.js", "resources/diff.html"])],
       )

--- a/tests/coverage.json
+++ b/tests/coverage.json
@@ -1,0 +1,3 @@
+{
+   "include": ["testsrunner"]
+}

--- a/tests/test_tr.py
+++ b/tests/test_tr.py
@@ -1,8 +1,6 @@
 import unittest
 import os
 import sys
-import subprocess
-import shlex
 
 this_dir = os.path.abspath(os.path.dirname(__file__))
 lib_dir = os.path.join(this_dir, '..', 'lib')
@@ -19,7 +17,6 @@ class TestRunnerBaseSubClass(TestRunnerBase):
                                                      options, options_files,
                                                      get_sample_data, test_data_files_info)
 
-
 class TestTestRunnerBase(unittest.TestCase):
     
     def testRun(self):
@@ -31,9 +28,7 @@ class TestTestRunnerBase(unittest.TestCase):
         options = [ "-s", "--with-coverage", "--cover-html", "--cover-xml", "--cover-package"]
         runner = TestRunnerBaseSubClass(testsuite_name, options=options,
                                         options_files=options_files)
-        ret_code = runner.run(workdir, tests="tests/test_hello.py")
+        ret_code = runner.run(workdir, tests="tests/test_tr_flake8.py")
         self.assertEqual(ret_code, 0)
 
-
-# python run_tests.py -v2 -n 2 tests/test_tr.py
 

--- a/tests/test_tr.py
+++ b/tests/test_tr.py
@@ -23,9 +23,9 @@ class TestTestRunnerBase(unittest.TestCase):
         workdir = os.path.join(os.path.dirname ( __file__), os.path.pardir)
         testsuite_name = "testsrunner"
         options_files = []
-        options_files.insert(0, os.path.join(
-                sys.prefix, "share", "testsrunner", "test_options_file.json"))
-        options = [ "-s", "--with-coverage", "--cover-html", "--cover-xml", "--cover-package"]
+        option_file = os.path.join(this_dir, '..', 'resources', 'test_options_file.json')
+        options_files.insert(0, option_file)
+        options = [ "-s", "--with-coverage", "--cover-html", "--cover-xml", "--cover-package" ]
         runner = TestRunnerBaseSubClass(testsuite_name, options=options,
                                         options_files=options_files)
         ret_code = runner.run(workdir, tests="tests/test_tr_flake8.py")

--- a/tests/test_tr.py
+++ b/tests/test_tr.py
@@ -1,0 +1,37 @@
+import unittest
+import os
+import sys
+import subprocess
+import shlex
+
+this_dir = os.path.abspath(os.path.dirname(__file__))
+lib_dir = os.path.join(this_dir, '..', 'lib')
+sys.path.append(lib_dir)
+
+from testsrunner import TestRunnerBase
+
+
+class TestRunnerBaseSubClass(TestRunnerBase):
+    def __init__(self, test_suite_name, options=[], options_files=[],
+                 get_sample_data=False,
+                 test_data_files_info=None):
+        super(TestRunnerBaseSubClass, self).__init__(test_suite_name,
+                                                     options, options_files,
+                                                     get_sample_data, test_data_files_info)
+
+
+class TestTestRunnerBase(unittest.TestCase):
+    
+    def testRun(self):
+        workdir = os.path.join(os.path.dirname ( __file__), os.path.pardir)
+        print("xxxxxx workdir: {}".format(workdir))
+        testsuite_name = "testsrunner"
+        options_files = []
+        options_files.insert(0, os.path.join(
+                sys.prefix, "share", "testsrunner", "test_options_file.json"))
+        
+        runner = TestRunnerBaseSubClass(testsuite_name, options_files=options_files)
+        print("xxxxxx calling runner.run() xxx")
+        ret_code = runner.run(workdir, tests="tests/test_hello.py")
+        self.assertEqual(ret_code, 0)
+

--- a/tests/test_tr.py
+++ b/tests/test_tr.py
@@ -24,14 +24,16 @@ class TestTestRunnerBase(unittest.TestCase):
     
     def testRun(self):
         workdir = os.path.join(os.path.dirname ( __file__), os.path.pardir)
-        print("xxxxxx workdir: {}".format(workdir))
         testsuite_name = "testsrunner"
         options_files = []
         options_files.insert(0, os.path.join(
                 sys.prefix, "share", "testsrunner", "test_options_file.json"))
-        
-        runner = TestRunnerBaseSubClass(testsuite_name, options_files=options_files)
-        print("xxxxxx calling runner.run() xxx")
+        options = [ "-s", "--with-coverage", "--cover-html", "--cover-xml", "--cover-package"]
+        runner = TestRunnerBaseSubClass(testsuite_name, options=options,
+                                        options_files=options_files)
         ret_code = runner.run(workdir, tests="tests/test_hello.py")
         self.assertEqual(ret_code, 0)
+
+
+# python run_tests.py -v2 -n 2 tests/test_tr.py
 


### PR DESCRIPTION
Add coverage support -- with this support, we can run run_tests.py with -c option.
TestRunnerBase.py expects tests/coverage.json in the repo where test suite resides.
tests/coverage.json lists the package name(s) that we want to get coverage on.

